### PR TITLE
Update burn function in M Token Spoke to burn only from msg.sender

### DIFF
--- a/src/MToken.sol
+++ b/src/MToken.sol
@@ -78,19 +78,8 @@ contract MToken is IMToken, ContinuousIndexing, ERC20Extended {
     }
 
     /// @inheritdoc IMToken
-    function burn(address account_, uint256 amount_) external onlyPortal {
-        uint256 portalAllowance_ = allowance[account_][portal];
-
-        if (portalAllowance_ != type(uint256).max) {
-            if (portalAllowance_ < amount_)
-                revert IERC20Extended.InsufficientAllowance(portal, portalAllowance_, amount_);
-
-            unchecked {
-                _setAllowance(account_, portal, portalAllowance_ - amount_);
-            }
-        }
-
-        _burn(account_, amount_);
+    function burn(uint256 amount_) external onlyPortal {
+        _burn(msg.sender, amount_);
     }
 
     /// @inheritdoc IContinuousIndexing

--- a/src/interfaces/IMToken.sol
+++ b/src/interfaces/IMToken.sol
@@ -65,13 +65,11 @@ interface IMToken is IContinuousIndexing, IERC20Extended {
     function mint(address account, uint256 amount, uint128 index) external;
 
     /**
-     * @notice Burns `amount` of M tokens from `account`.
+     * @notice Burns `amount` of M tokens from `msg.sender`.
      * @dev    MUST only be callable by the Spoke Portal.
-     * @dev    MUST revert if `account` has not approved the Spoke Portal to burn their M tokens.
-     * @param  account The address of the account to burn from.
      * @param  amount  The amount of M Token to burn.
      */
-    function burn(address account, uint256 amount) external;
+    function burn(uint256 amount) external;
 
     /// @notice Starts earning for caller if allowed by TTG.
     function startEarning() external;


### PR DESCRIPTION
### Summary

The external `burn()` function in M Token Spoke has been updated to allow only burning tokens from the sender to be compatible with the token interface used in Wormhole `NttManager` . See https://github.com/wormholelabs-xyz/example-native-token-transfers/blob/custom-payload/evm/src/interfaces/INttToken.sol#L37