### PR TITLE
refactor: revert if index is decreasing in MToken updateIndex

### DIFF
--- a/src/MToken.sol
+++ b/src/MToken.sol
@@ -6,7 +6,6 @@ import { ERC20Extended } from "../lib/common/src/ERC20Extended.sol";
 import { UIntMath } from "../lib/common/src/libs/UIntMath.sol";
 
 import { IERC20 } from "../lib/common/src/interfaces/IERC20.sol";
-import { IERC20Extended } from "../lib/common/src/interfaces/IERC20Extended.sol";
 
 import { RegistrarReader } from "./libs/RegistrarReader.sol";
 
@@ -73,7 +72,12 @@ contract MToken is IMToken, ContinuousIndexing, ERC20Extended {
 
     /// @inheritdoc IMToken
     function mint(address account_, uint256 amount_, uint128 index_) external onlyPortal {
-        super.updateIndex(index_);
+        _updateIndex(index_);
+        _mint(account_, amount_);
+    }
+
+    /// @inheritdoc IMToken
+    function mint(address account_, uint256 amount_) external onlyPortal {
         _mint(account_, amount_);
     }
 
@@ -82,9 +86,9 @@ contract MToken is IMToken, ContinuousIndexing, ERC20Extended {
         _burn(msg.sender, amount_);
     }
 
-    /// @inheritdoc IContinuousIndexing
-    function updateIndex(uint128 index_) public override(IContinuousIndexing, ContinuousIndexing) onlyPortal {
-        super.updateIndex(index_);
+    /// @inheritdoc IMToken
+    function updateIndex(uint128 index_) external onlyPortal {
+        _updateIndex(index_);
     }
 
     /// @inheritdoc IMToken

--- a/src/abstract/ContinuousIndexing.sol
+++ b/src/abstract/ContinuousIndexing.sol
@@ -39,6 +39,7 @@ abstract contract ContinuousIndexing is IContinuousIndexing {
      * @param  index_ The new index to compute present amounts from principal amounts.
      */
     function _updateIndex(uint128 index_) internal virtual {
+        if (index_ < latestIndex) revert DecreasingIndex(index_, latestIndex);
         latestIndex = index_;
         latestUpdateTimestamp = uint40(block.timestamp);
 

--- a/src/abstract/ContinuousIndexing.sol
+++ b/src/abstract/ContinuousIndexing.sol
@@ -27,22 +27,23 @@ abstract contract ContinuousIndexing is IContinuousIndexing {
         latestUpdateTimestamp = uint40(block.timestamp);
     }
 
-    /* ============ Interactive Functions ============ */
+    /* ============ View/Pure Functions ============ */
 
     /// @inheritdoc IContinuousIndexing
-    function updateIndex(uint128 index_) public virtual {
-        if (index_ <= latestIndex) return;
+    function currentIndex() public view virtual returns (uint128);
 
+    /* ============ Internal Interactive Functions ============ */
+
+    /**
+     * @notice Updates the latest index and latest accrual time.
+     * @param  index_ The new index to compute present amounts from principal amounts.
+     */
+    function _updateIndex(uint128 index_) internal virtual {
         latestIndex = index_;
         latestUpdateTimestamp = uint40(block.timestamp);
 
         emit IndexUpdated(index_);
     }
-
-    /* ============ View/Pure Functions ============ */
-
-    /// @inheritdoc IContinuousIndexing
-    function currentIndex() public view virtual returns (uint128);
 
     /* ============ Internal View/Pure Functions ============ */
 

--- a/src/interfaces/IContinuousIndexing.sol
+++ b/src/interfaces/IContinuousIndexing.sol
@@ -15,6 +15,15 @@ interface IContinuousIndexing {
      */
     event IndexUpdated(uint128 indexed index);
 
+    /* ============ Custom Error ============ */
+
+    /**
+     * @notice Emitted during index update when the new index is less than the current one.
+     * @param  index The new index.
+     * @param  currentIndex The current index.
+     */
+    error DecreasingIndex(uint128 index, uint128 currentIndex);
+
     /* ============ View/Pure Functions ============ */
 
     /// @notice The current index that would be written to storage if `updateIndex` is called.

--- a/src/interfaces/IContinuousIndexing.sol
+++ b/src/interfaces/IContinuousIndexing.sol
@@ -15,14 +15,6 @@ interface IContinuousIndexing {
      */
     event IndexUpdated(uint128 indexed index);
 
-    /* ============ Interactive Functions ============ */
-
-    /**
-     * @notice Updates the latest index and latest accrual time in storage.
-     * @param  index The new index to compute present amounts from principal amounts.
-     */
-    function updateIndex(uint128 index) external;
-
     /* ============ View/Pure Functions ============ */
 
     /// @notice The current index that would be written to storage if `updateIndex` is called.

--- a/src/interfaces/IMToken.sol
+++ b/src/interfaces/IMToken.sol
@@ -65,11 +65,26 @@ interface IMToken is IContinuousIndexing, IERC20Extended {
     function mint(address account, uint256 amount, uint128 index) external;
 
     /**
+     * @notice Mints tokens.
+     * @dev    MUST only be callable by the Spoke Portal.
+     * @param  account The address of account to mint to.
+     * @param  amount  The amount of M Token to mint.
+     */
+    function mint(address account, uint256 amount) external;
+
+    /**
      * @notice Burns `amount` of M tokens from `msg.sender`.
      * @dev    MUST only be callable by the Spoke Portal.
      * @param  amount  The amount of M Token to burn.
      */
     function burn(uint256 amount) external;
+
+    /**
+     * @notice Updates the latest index and latest accrual time in storage.
+     * @dev    MUST only be callable by the Spoke Portal.
+     * @param  index The new index to compute present amounts from principal amounts.
+     */
+    function updateIndex(uint128 index) external;
 
     /// @notice Starts earning for caller if allowed by TTG.
     function startEarning() external;

--- a/test/MToken.t.sol
+++ b/test/MToken.t.sol
@@ -5,6 +5,7 @@ pragma solidity 0.8.26;
 import { IERC20Extended } from "../lib/common/src/interfaces/IERC20Extended.sol";
 import { UIntMath } from "../lib/common/src/libs/UIntMath.sol";
 
+import { IContinuousIndexing } from "../src/interfaces/IContinuousIndexing.sol";
 import { IMToken } from "../src/interfaces/IMToken.sol";
 
 import { ContinuousIndexingMath } from "../src/libs/ContinuousIndexingMath.sol";
@@ -82,6 +83,18 @@ contract MTokenTests is TestUtils {
 
         vm.prank(_portal);
         _mToken.mint(address(0), 1_000);
+    }
+
+    function test_mint_mintAndUpdateIndex_decreasingIndex() external {
+        uint256 amount_ = 1_000;
+        uint128 index_ = 1;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(IContinuousIndexing.DecreasingIndex.selector, index_, _mToken.currentIndex())
+        );
+
+        vm.prank(_portal);
+        _mToken.mint(_alice, amount_, index_);
     }
 
     function test_mint_mintAndUpdateIndex() external {
@@ -842,6 +855,16 @@ contract MTokenTests is TestUtils {
     function test_updateIndex_notPortal() external {
         vm.expectRevert(IMToken.NotPortal.selector);
         _mToken.updateIndex(0);
+    }
+
+    function test_updateIndex_decreasingIndex() external {
+        uint128 index_ = 0;
+        vm.expectRevert(
+            abi.encodeWithSelector(IContinuousIndexing.DecreasingIndex.selector, index_, _mToken.currentIndex())
+        );
+
+        vm.prank(_portal);
+        _mToken.updateIndex(index_);
     }
 
     function test_updateIndex() external {


### PR DESCRIPTION
### Proposed changes:

 - revert if index is decreasing in `updateIndex` function.
 - add `mint` function that doesn't take `index` parameter. It will be called by Portal when index updating isn't required.
 - make `updateIndex` function in `ContinuousIndexing` internal.
 
 ### Related PR:
 
 https://github.com/m0-foundation/m-portal/pull/10