### PR TITLE
feat: 98% safety rate multiplier in Earner rate model

### DIFF
--- a/src/rateModels/EarnerRateModel.sol
+++ b/src/rateModels/EarnerRateModel.sol
@@ -78,13 +78,16 @@ contract EarnerRateModel is IEarnerRateModel {
         return uint256(ITTGRegistrar(ttgRegistrar).get(_MAX_EARNER_RATE));
     }
 
+    /// @inheritdoc IEarnerRateModel
     function getExtraSafeEarnerRate(
         uint240 totalActiveOwedM_,
         uint240 totalEarningSupply_,
         uint32 minterRate_
-    ) public pure returns (uint256) {
+    ) public pure returns (uint32) {
         uint256 safeEarnerRate_ = getSafeEarnerRate(totalActiveOwedM_, totalEarningSupply_, minterRate_);
-        return (RATE_MULTIPLIER * safeEarnerRate_) / ONE;
+        uint256 extraSafeEarnerRate_ = (safeEarnerRate_ * RATE_MULTIPLIER) / ONE;
+
+        return (extraSafeEarnerRate_ > type(uint32).max) ? type(uint32).max : uint32(extraSafeEarnerRate_);
     }
 
     /// @inheritdoc IEarnerRateModel

--- a/src/rateModels/EarnerRateModel.sol
+++ b/src/rateModels/EarnerRateModel.sol
@@ -25,7 +25,7 @@ contract EarnerRateModel is IEarnerRateModel {
     uint32 public constant RATE_CONFIDENCE_INTERVAL = 30 days;
 
     /// @inheritdoc IEarnerRateModel
-    uint32 public constant RATE_MULTIPLIER = 9_000; // 90% in basis points.
+    uint32 public constant RATE_MULTIPLIER = 9_800; // 98% in basis points.
 
     /// @inheritdoc IEarnerRateModel
     uint32 public constant ONE = 10_000; // 100% in basis points.
@@ -64,18 +64,27 @@ contract EarnerRateModel is IEarnerRateModel {
 
     /// @inheritdoc IRateModel
     function rate() external view returns (uint256) {
-        uint256 safeEarnerRate_ = getSafeEarnerRate(
+        uint256 extraSafeEarnerRate_ = getExtraSafeEarnerRate(
             IMinterGateway(minterGateway).totalActiveOwedM(),
             IMToken(mToken).totalEarningSupply(),
             IMinterGateway(minterGateway).minterRate()
         );
 
-        return UIntMath.min256(maxRate(), (RATE_MULTIPLIER * safeEarnerRate_) / ONE);
+        return UIntMath.min256(maxRate(), extraSafeEarnerRate_);
     }
 
     /// @inheritdoc IEarnerRateModel
     function maxRate() public view returns (uint256) {
         return uint256(ITTGRegistrar(ttgRegistrar).get(_MAX_EARNER_RATE));
+    }
+
+    function getExtraSafeEarnerRate(
+        uint240 totalActiveOwedM_,
+        uint240 totalEarningSupply_,
+        uint32 minterRate_
+    ) public pure returns (uint256) {
+        uint256 safeEarnerRate_ = getSafeEarnerRate(totalActiveOwedM_, totalEarningSupply_, minterRate_);
+        return (RATE_MULTIPLIER * safeEarnerRate_) / ONE;
     }
 
     /// @inheritdoc IEarnerRateModel

--- a/src/rateModels/EarnerRateModel.sol
+++ b/src/rateModels/EarnerRateModel.sol
@@ -64,13 +64,15 @@ contract EarnerRateModel is IEarnerRateModel {
 
     /// @inheritdoc IRateModel
     function rate() external view returns (uint256) {
-        uint256 extraSafeEarnerRate_ = getExtraSafeEarnerRate(
-            IMinterGateway(minterGateway).totalActiveOwedM(),
-            IMToken(mToken).totalEarningSupply(),
-            IMinterGateway(minterGateway).minterRate()
-        );
-
-        return UIntMath.min256(maxRate(), extraSafeEarnerRate_);
+        return
+            UIntMath.min256(
+                maxRate(),
+                getExtraSafeEarnerRate(
+                    IMinterGateway(minterGateway).totalActiveOwedM(),
+                    IMToken(mToken).totalEarningSupply(),
+                    IMinterGateway(minterGateway).minterRate()
+                )
+            );
     }
 
     /// @inheritdoc IEarnerRateModel

--- a/src/rateModels/interfaces/IEarnerRateModel.sol
+++ b/src/rateModels/interfaces/IEarnerRateModel.sol
@@ -55,4 +55,18 @@ interface IEarnerRateModel is IRateModel {
         uint240 totalEarningSupply,
         uint32 minterRate
     ) external pure returns (uint32);
+
+    /**
+     * @notice Returns the extra safe earner rate - safe earner rate adjusted by `RATE_MULTIPLIER`.
+     * @dev    `extraSafeEarnerRate = safeEarnerRate * RATE_MULTIPLIER`
+     * @param  totalActiveOwedM   The total active owed M.
+     * @param  totalEarningSupply The total earning supply of M Token.
+     * @param  minterRate         The minter rate.
+     * @return The extra safe earner rate.
+     */
+    function getExtraSafeEarnerRate(
+        uint240 totalActiveOwedM,
+        uint240 totalEarningSupply,
+        uint32 minterRate
+    ) external pure returns (uint256);
 }

--- a/src/rateModels/interfaces/IEarnerRateModel.sol
+++ b/src/rateModels/interfaces/IEarnerRateModel.sol
@@ -68,5 +68,5 @@ interface IEarnerRateModel is IRateModel {
         uint240 totalActiveOwedM,
         uint240 totalEarningSupply,
         uint32 minterRate
-    ) external pure returns (uint256);
+    ) external pure returns (uint32);
 }

--- a/test/integration/minter-gateway/Integration.t.sol
+++ b/test/integration/minter-gateway/Integration.t.sol
@@ -59,7 +59,7 @@ contract IntegrationTests is IntegrationBaseSetup {
         _minterGateway.burnM(_minters[0], aliceBalance);
 
         assertEq(_minterGateway.activeOwedMOf(_minters[0]), 0);
-        assertEq(_mToken.balanceOf(_alice), aliceBalance - minterOwedM - 1);
+        assertEq(_mToken.balanceOf(_alice), aliceBalance - minterOwedM);
 
         // Minter can mint again without imposing any penalties for missed collateral updates
         vm.warp(vm.getBlockTimestamp() + 60 days);
@@ -311,7 +311,7 @@ contract IntegrationTests is IntegrationBaseSetup {
         assertEq(_minterGateway.totalActiveOwedM(), 500_457040);
         assertEq(_mToken.totalEarningSupply(), 249_999999);
         assertEq(_minterGateway.minterRate(), 40_000);
-        assertEq(_mToken.earnerRate(), 63_090);
+        assertEq(_mToken.earnerRate(), 68_698);
 
         uint256 timestamp_ = vm.getBlockTimestamp();
 
@@ -387,9 +387,9 @@ contract IntegrationTests is IntegrationBaseSetup {
         assertGe(_minterGateway.totalOwedM(), _mToken.totalSupply());
 
         assertEq(_minterGateway.totalActiveOwedM(), 500_000001);
-        assertEq(_mToken.totalEarningSupply(), 1301_316149);
+        assertEq(_mToken.totalEarningSupply(), 1301_433245);
         assertEq(_minterGateway.minterRate(), 40_000);
-        assertEq(_mToken.earnerRate(), 13_832);
+        assertEq(_mToken.earnerRate(), 15_059);
 
         uint256 timestamp_ = vm.getBlockTimestamp();
 


### PR DESCRIPTION
In addition to the actual switch from 90% to 98% multiplier, a public getter function `getExtraSafeRate` was introduced. 

It will be used by M^0 colleagues to predict/query an expected rate based on `totalEarningSupply`, `totalActiveOwedM`, `minterRate` without knowing extra details about the rate multiplier. 

