### PR TITLE
fix(MToken): disable startEarning if index has not been initialized

### DIFF
--- a/src/MToken.sol
+++ b/src/MToken.sol
@@ -13,6 +13,7 @@ import { IContinuousIndexing } from "./interfaces/IContinuousIndexing.sol";
 import { IMToken } from "./interfaces/IMToken.sol";
 
 import { ContinuousIndexing } from "./abstract/ContinuousIndexing.sol";
+import { ContinuousIndexingMath } from "./libs/ContinuousIndexingMath.sol";
 
 /**
  * @title  MToken
@@ -94,6 +95,7 @@ contract MToken is IMToken, ContinuousIndexing, ERC20Extended {
     /// @inheritdoc IMToken
     function startEarning() external {
         if (!_isApprovedEarner(msg.sender)) revert NotApprovedEarner();
+        if (currentIndex() == ContinuousIndexingMath.EXP_SCALED_ONE) revert IndexNotInitialized();
 
         _startEarning(msg.sender);
     }

--- a/src/interfaces/IMToken.sol
+++ b/src/interfaces/IMToken.sol
@@ -27,6 +27,9 @@ interface IMToken is IContinuousIndexing, IERC20Extended {
 
     /* ============ Custom Errors ============ */
 
+    /// @notice Emitted when the index from the Hub chain has not yet been propagated to the Spoke chain.
+    error IndexNotInitialized();
+
     /**
      * @notice Emitted when there is insufficient balance to decrement from `account`.
      * @param  account     The account with insufficient balance.

--- a/test/MToken.t.sol
+++ b/test/MToken.t.sol
@@ -692,6 +692,16 @@ contract MTokenTests is TestUtils {
         _mToken.startEarning();
     }
 
+    function test_startEarning_indexNotInitialized() external {
+        _mToken.setLatestIndex(ContinuousIndexingMath.EXP_SCALED_ONE);
+        _registrar.addToList(RegistrarReader.EARNERS_LIST, _alice);
+
+        vm.expectRevert(IMToken.IndexNotInitialized.selector);
+
+        vm.prank(_alice);
+        _mToken.startEarning();
+    }
+
     function test_startEarning() external {
         _mToken.setTotalNonEarningSupply(1_000);
 
@@ -739,9 +749,9 @@ contract MTokenTests is TestUtils {
     }
 
     function test_startEarning_overflow() external {
-        _mToken.setLatestIndex(ContinuousIndexingMath.EXP_SCALED_ONE);
+        _mToken.setLatestIndex(ContinuousIndexingMath.EXP_SCALED_ONE + 1);
 
-        uint256 aliceBalance_ = uint256(type(uint112).max) + 20;
+        uint256 aliceBalance_ = uint256(type(uint112).max) + 1e22;
 
         _mToken.setTotalNonEarningSupply(aliceBalance_);
         _mToken.setInternalBalanceOf(_alice, aliceBalance_);


### PR DESCRIPTION
Fix Kirill's M01 Accrual of unbacked yield when enabling earning for HubPortal